### PR TITLE
[Fishnet_v4.1.6R_WebGL] Rewrite Matchmaking System

### DIFF
--- a/Fishnet_v4.1.6R_WebGL/Assets/SpaceEdge/Scripts/Systems/MatchmakingSystem.cs
+++ b/Fishnet_v4.1.6R_WebGL/Assets/SpaceEdge/Scripts/Systems/MatchmakingSystem.cs
@@ -1,13 +1,9 @@
-using System;
-using System.Net;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
 using FishNet;
 using Leguar.TotalJSON;
+using System;
+using System.Collections;
 using UnityEngine;
+using UnityEngine.Networking;
 
 
 namespace SpaceEdge
@@ -60,7 +56,7 @@ namespace SpaceEdge
         ///     Refer to https://docs.edgegap.com/api/#operation/deployment-status-get for details.
         /// </summary>
         private const string AppListURL = "https://api.edgegap.com/v1/deployments";
-        
+
         /// <summary>
         ///     The URL to get the public ip of the player.
         ///     Refer to https://docs.edgegap.com/api/#operation/IP for details.
@@ -68,46 +64,34 @@ namespace SpaceEdge
         private const string PublicIpURL = "https://api.edgegap.com/v1/ip";
 
         /// <summary>
-        ///     The HTTP client that will handle all the communication with the EdgeGap API.
+        ///     Stores the JSON request data that is properly formatted
+        ///     for properly delivering the UnityWebRequest to the EdgeGap API.
         /// </summary>
-        private readonly HttpClient _httpClient = new();
+        private string _requestData;
 
         /// <summary>
-        ///     The request object that sends the "_requestData" via the "_httpClient".
-        /// </summary>
-        private HttpResponseMessage _request;
-
-        /// <summary>
-        ///     Stores the JSON request data that is properly formatted and converted to a ByteArray
-        ///     for properly delivering the HTTP request to the EdgeGap API.
-        /// </summary>
-        private StringContent _requestData;
-
-        /// <summary>
-        ///     Used by the "StartConnectionAttempt" method to communicate with and keep track of the deployment instance
-        ///     it's attempting to connect to. This variable is either populated by the "FindDeployedServers" method if trying
-        ///     to connect to an existing deployment , or by the "DeployNewServer" method if attempting a new deployment.
+        ///     Used by the "StartConnectionAttempt" coroutine to communicate with and keep track of the deployment instance
+        ///     it's attempting to connect to. This variable is either populated by the "RequestServers" coroutine if trying
+        ///     to connect to an existing deployment , or by the "DeployNewServer" coroutine if attempting a new deployment.
         /// </summary>
         private string _requestId;
 
         /// <summary>
-        ///     Acts as a buffer for HTTP request's response that is read asynchronously.
+        ///     Store the response from UnityWebRequests.
         /// </summary>
         private string _response;
 
         private string _publicIP;
-        
+
         public Action OnStartGameFailed;
 
         //These public events are used to communicate with the "MainMenuSystem".
         public Action<string, bool> OnStatusUpdate;
 
 
-        private void Awake()
+        public void FindDeployedServers()
         {
-            //Setting the proper Content-Type and Authorization header values to the _httpClient.
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(TypeHeaderValue));
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", AuthHeaderValue);
+            StartCoroutine(RequestServers());
         }
 
         /// <summary>
@@ -116,47 +100,51 @@ namespace SpaceEdge
         ///     to the first one makes the most sense. But in case of paid tier account this method can be extended
         ///     easily to allow players to select any preferred deployment from the list and connect to it.
         /// </summary>
-        public async void FindDeployedServers()
+        private IEnumerator RequestServers()
         {
             //Request the list of deployments by sending a HTTP GET request to the AppListURL on EdgeGap API
-            _request = await _httpClient.GetAsync(AppListURL);
-            //Store the response into the buffer.
-            _response = await _request.Content.ReadAsStringAsync();
-
-            //If the request is successful.
-            if (_request.IsSuccessStatusCode)
+            using (UnityWebRequest webRequest = UnityWebRequest.Get(AppListURL))
             {
-                //Parse the response string into a JSON object
-                var responseJson = JSON.ParseString(_response);
-                //If total count of deployments is 0 then start new server deployment.
-                if (responseJson.GetInt("total_count") == 0)
-                {
-                    OnStatusUpdate?.Invoke("No Deployed Servers Found, Attempting To Deploy A New Instance ", false);
+                SetCustomHeaders(webRequest);
+                yield return webRequest.SendWebRequest();
 
-                    //Attempt to deploy new server as no instances are found.
-                    DeployNewServer();
+                _response = webRequest.downloadHandler.text;
+
+                //If the request is successful.
+                if (webRequest.result == UnityWebRequest.Result.Success)
+                {
+                    //Parse the response string into a JSON object
+                    var responseJson = JSON.ParseString(_response);
+                    //If total count of deployments is 0 then start new server deployment.
+                    if (responseJson.GetInt("total_count") == 0)
+                    {
+                        OnStatusUpdate?.Invoke("No Deployed Servers Found, Attempting To Deploy A New Instance ", false);
+
+                        //Attempt to deploy new server as no instances are found.
+                        StartCoroutine(DeployNewServer());
+                    }
+                    //Else connect to the first instance of the deployment from the deployments list.
+                    else
+                    {
+                        OnStatusUpdate?.Invoke("Found Deployed Servers, Attempting Connection..", false);
+                        //Parse the deployments list into a JSON Array.
+                        var allServers = responseJson.GetJArray("data");
+                        //Grab the entry from the first index of the JSON Array.
+                        var firstServer = allServers.GetJSON(0);
+                        //Populate the _requestID with the first server's "request_id" parameter.
+                        _requestId = firstServer.GetString("request_id");
+                        //Attempt to connect to the server.
+                        StartCoroutine(StartConnectionAttempt());
+                    }
                 }
-                //Else connect to the first instance of the deployment from the deployments list.
+                //Invoked in case of an unexpected error.
                 else
                 {
-                    OnStatusUpdate?.Invoke("Found Deployed Servers, Attempting Connection..", false);
-                    //Parse the deployments list into a JSON Array.
-                    var allServers = responseJson.GetJArray("data");
-                    //Grab the entry from the first index of the JSON Array.
-                    var firstServer = allServers.GetJSON(0);
-                    //Populate the _requestID with the first server's "request_id" parameter.
-                    _requestId = firstServer.GetString("request_id");
-                    //Attempt to connect to the server.
-                    StartConnectionAttempt();
+                    OnStatusUpdate?.Invoke(
+                        $"Could Not Start Game, Error {(int)webRequest.responseCode} With Message: \n{_response}",
+                        true);
+                    OnStartGameFailed?.Invoke();
                 }
-            }
-            //Invoked in case of an unexpected error.
-            else
-            {
-                OnStatusUpdate?.Invoke(
-                    $"Could Not Start Game, Error {(int)_request.StatusCode} With Message: \n{_response}",
-                    true);
-                OnStartGameFailed?.Invoke();
             }
         }
 
@@ -164,14 +152,14 @@ namespace SpaceEdge
         ///     This method configures and sends a POST request to the EdgeGap API for deploying a new server instance
         ///     If the server deployment is successful, the "StartConnectionAttempt" method is called.
         /// </summary>
-        public async void DeployNewServer()
+        private IEnumerator DeployNewServer()
         {
             //Get the public ip of the player. If null or empty then return from the function
-            //GetLocalIPAddress method will take care of error handling and logging.
-            await GetLocalIPAddress();
-            if(String.IsNullOrEmpty(_publicIP))
-                return;
-            
+            //GetLocalIpAddress method will take care of error handling and logging.
+            yield return GetLocalIpAddress();
+            if (String.IsNullOrEmpty(_publicIP))
+                yield break;
+
             //Create a new JSON object and add the minimum required fields for a deployment.
             var requestJson = new JSON();
             //Please refer to https://docs.edgegap.com/api/#operation/deploy for more details.
@@ -179,119 +167,141 @@ namespace SpaceEdge
             requestJson.Add("version_name", AppVersion);
             requestJson.Add("ip_list", new[] { _publicIP });
             //Convert the JSON object to a ByteArray and format it for "application/json" Content-Type.
-            _requestData = new StringContent(requestJson.CreateString(), Encoding.UTF8, TypeHeaderValue);
+            _requestData = requestJson.CreateString();
             //Request new deployment by sending HTTP POST request to the AppDeployURL on EdgeGap API.
-            _request = await _httpClient.PostAsync(AppDeployURL, _requestData);
-            //Store the response inti the buffer.
-            _response = await _request.Content.ReadAsStringAsync();
 
-            //If the request is successful.
-            if (_request.IsSuccessStatusCode)
+            using (UnityWebRequest webRequest = UnityWebRequest.Post(AppDeployURL, _requestData, TypeHeaderValue))
             {
-                //Parse the response string into a JSON object.
-                var responseJson = JSON.ParseString(_response);
-                //Fetch the response_id of the deployed server.
-                _requestId = responseJson.GetString("request_id");
-                //Start connection attempt to the deployed server.
-                OnStatusUpdate?.Invoke("Server Deployment Successful, Attempting To Connect To Server...", false);
-                StartConnectionAttempt();
-            }
-            //Invoked in case of an unexpected error.
-            else
-            {
-                OnStatusUpdate?.Invoke(
-                    $"Could Not Deploy Server, Error {(int)_request.StatusCode} With Message: \n{_response}",
-                    true);
-                OnStartGameFailed?.Invoke();
-            }
-        }
+                SetCustomHeaders(webRequest);
+                yield return webRequest.SendWebRequest();
 
+                _response = webRequest.downloadHandler.text;
 
-        private async void StartConnectionAttempt()
-        {
-            var isServerReady = false;
-            while (!isServerReady)
-            {
-                //Send a GET HTTP request to the EdgeGap api to get the status of the deployment linked to the _requestId.
-                _request = await _httpClient.GetAsync(AppStatusURL + _requestId);
-                _response = await _request.Content.ReadAsStringAsync();
-
-                if (_request.IsSuccessStatusCode)
+                //If the request is successful.
+                if (webRequest.result == UnityWebRequest.Result.Success)
                 {
+                    //Parse the response string into a JSON object.
                     var responseJson = JSON.ParseString(_response);
-
-                    isServerReady = responseJson.GetBool("running");
-                    //If the response has the "running" bool as "true" then the server is running and ready for connection.
-                    if (isServerReady)
-                    {
-                        OnStatusUpdate?.Invoke("Server Is Ready For Connection, Starting The Game...", false);
-                        //Grab the port number of the port named "Game Port" from the "ports" object in the responseJson.
-                        //For more information on how to configure ports please refer to the "FishNet Example Guide".
-                        var serverPort = (ushort)responseJson.GetJSON("ports").GetJSON("Game Port").GetInt("external");
-                        //The "fqdn" string in the responseJson represents the server address to which we want the client to connect.
-                        var serverAddress = responseJson.GetString("fqdn");
-
-                        //Set the serverPort and serverAddress to the default transport (Tugboat)
-                        InstanceFinder.TransportManager.Transport.SetPort(serverPort);
-                        InstanceFinder.TransportManager.Transport.SetClientAddress(serverAddress);
-                        Debug.Log($"Connecting To Server Using Port {serverPort} And IP {serverAddress}");
-                        //StartConnection method will connect to the server with the given port and address.
-                        //Once the connection is complete the SceneManager will auto load the "OnlineScene".
-                        //Please refer to the "FishNet Example Guide" for more details on SceneManager.
-                        InstanceFinder.ClientManager.StartConnection();
-                    }
-                    //If the server is not ready for connection, we delay the function execution for 10 seconds.
-                    //After 10 seconds the loop will run again as the "isServerReady" bool is still set to false 
-                    else
-                    {
-                        OnStatusUpdate?.Invoke("Server Is Not Ready For Connection Retrying In 10 Seconds...", false);
-                        await Task.Delay(10000);
-                    }
+                    //Fetch the response_id of the deployed server.
+                    _requestId = responseJson.GetString("request_id");
+                    //Start connection attempt to the deployed server.
+                    OnStatusUpdate?.Invoke("Server Deployment Successful, Attempting To Connect To Server...", false);
+                    StartCoroutine(StartConnectionAttempt());
                 }
-                //Invoked in case of an unexpected error
+                //Invoked in case of an unexpected error.
                 else
                 {
                     OnStatusUpdate?.Invoke(
-                        $"Could Not Update Server Status, Error {(int)_request.StatusCode} With Message: \n{_response}",
+                        $"Could Not Deploy Server, Error {(int)webRequest.responseCode} With Message: \n{_response}",
                         true);
                     OnStartGameFailed?.Invoke();
                 }
             }
         }
 
-        //Function to get the IP address of the client's device
-        private async Task GetLocalIPAddress()
+        private IEnumerator StartConnectionAttempt()
         {
-            //Request the public ip of the player using the EdgeGap API 
-            _request = await _httpClient.GetAsync(PublicIpURL);
-            //Store the response into the buffer.
-            _response = await _request.Content.ReadAsStringAsync();
-
-          
-            if (_request.IsSuccessStatusCode)
+            var isServerReady = false;
+            while (!isServerReady)
             {
-                OnStatusUpdate?.Invoke("Fetching The Public Ip Address",false);
-                var responseJson = JSON.ParseString(_response);
-                var ip = responseJson.GetString("public_ip");
-                if (String.IsNullOrEmpty(ip))
+                //Send a GET HTTP request to the EdgeGap api to get the status of the deployment linked to the _requestId.
+                using (UnityWebRequest webRequest = UnityWebRequest.Get(AppStatusURL + _requestId))
                 {
-                    OnStatusUpdate?.Invoke("Failed To Get Player Public Ip",true);
-                    OnStartGameFailed?.Invoke();
+                    SetCustomHeaders(webRequest);
+                    yield return webRequest.SendWebRequest();
+
+                    _response = webRequest.downloadHandler.text;
+
+                    //If the request is successful.
+                    if (webRequest.result == UnityWebRequest.Result.Success)
+                    {
+                        var responseJson = JSON.ParseString(_response);
+
+                        isServerReady = responseJson.GetBool("running");
+                        //If the response has the "running" bool as "true" then the server is running and ready for connection.
+                        if (isServerReady)
+                        {
+                            OnStatusUpdate?.Invoke("Server Is Ready For Connection, Starting The Game...", false);
+                            //Grab the port number of the port named "Game Port" from the "ports" object in the responseJson.
+                            //For more information on how to configure ports please refer to the "FishNet Example Guide".
+                            var serverPort = (ushort)responseJson.GetJSON("ports").GetJSON("Game Port").GetInt("external");
+                            //The "fqdn" string in the responseJson represents the server address to which we want the client to connect.
+                            var serverAddress = responseJson.GetString("fqdn");
+
+                            //Set the serverPort and serverAddress to the default transport (Tugboat)
+                            InstanceFinder.TransportManager.Transport.SetPort(serverPort);
+                            //InstanceFinder.TransportManager.Transport.SetPort(7770);
+                            InstanceFinder.TransportManager.Transport.SetClientAddress(serverAddress);
+                            Debug.Log($"Connecting To Server Using Port {serverPort} And IP {serverAddress}");
+                            //StartConnection method will connect to the server with the given port and address.
+                            //Once the connection is complete the SceneManager will auto load the "OnlineScene".
+                            //Please refer to the "FishNet Example Guide" for more details on SceneManager.
+                            InstanceFinder.ClientManager.StartConnection();
+                        }
+                        //If the server is not ready for connection, we delay the function execution for 10 seconds.
+                        //After 10 seconds the loop will run again as the "isServerReady" bool is still set to false 
+                        else
+                        {
+                            OnStatusUpdate?.Invoke("Server Is Not Ready For Connection Retrying In 10 Seconds...", false);
+                        }
+                    }
+                    //Invoked in case of an unexpected error.
+                    else
+                    {
+                        OnStatusUpdate?.Invoke(
+                        $"Could Not Update Server Status, Error {(int)webRequest.responseCode} With Message: \n{_response}",
+                        true);
+                        OnStartGameFailed?.Invoke();
+                    }
                 }
+                yield return new WaitForSeconds(10);
+            }
+        }
+
+        //Coroutine to get the IP address of the client's device
+        private IEnumerator GetLocalIpAddress()
+        {
+            using (UnityWebRequest webRequest = UnityWebRequest.Get(PublicIpURL))
+            {
+                SetCustomHeaders(webRequest);
+                yield return webRequest.SendWebRequest();
+
+                _response = webRequest.downloadHandler.text;
+
+                //If the request is successful.
+                if (webRequest.result == UnityWebRequest.Result.Success)
+                {
+                    OnStatusUpdate?.Invoke("Fetching The Public Ip Address", false);
+                    var responseJson = JSON.ParseString(_response);
+                    var ip = responseJson.GetString("public_ip");
+                    if (String.IsNullOrEmpty(ip))
+                    {
+                        OnStatusUpdate?.Invoke("Failed To Get Player Public Ip", true);
+                        OnStartGameFailed?.Invoke();
+                    }
+                    else
+                    {
+                        OnStatusUpdate?.Invoke($"Public Ip Address is {ip}", false);
+                        _publicIP = ip;
+                    }
+                }
+                //Invoked in case of an unexpected error.
                 else
                 {
-                    OnStatusUpdate?.Invoke($"Public Ip Address is {ip}",false);
-                    _publicIP = ip;
+                    OnStatusUpdate?.Invoke(
+                    $"Could Not Get Player Ip, Error {(int)webRequest.responseCode} With Message: \n{_response}",
+                    true);
+                    OnStartGameFailed?.Invoke();
                 }
             }
-            else
-            {
-                OnStatusUpdate?.Invoke(
-                    $"Could Not Get Player Ip, Error {(int)_request.StatusCode} With Message: \n{_response}",
-                    true);
-                OnStartGameFailed?.Invoke();
-                
-            }
+        }
+
+        //Utility function to configure every UnityWebRequest
+        private void SetCustomHeaders(UnityWebRequest request)
+        {
+            //Setting the proper Content-Type and Authorization header values to the _httpClient.
+            request.SetRequestHeader("Accept", TypeHeaderValue);
+            request.SetRequestHeader("Authorization", "token " + AuthHeaderValue);
         }
     }
 }

--- a/Fishnet_v4.1.6R_WebGL/Assets/SpaceEdge/Scripts/Systems/MatchmakingSystem.cs.meta
+++ b/Fishnet_v4.1.6R_WebGL/Assets/SpaceEdge/Scripts/Systems/MatchmakingSystem.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b259e353e158c456d85dce46edc50782
+guid: 5b0fc49f25a41e541a8b5171abe9af68
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
- Rewrite MatchmakingSystem to use coroutines and UnityWebRequests instead of Threading.Tasks and await keyword (which are not supported in webgl)
- Tested with webgl itch build successfully

Notes:
- Original issue can be found [here](https://discord.com/channels/758432814739226674/1077604429701845164/1255643655688032367)
- The [tutorial](https://docs.edgegap.com/docs/sample-projects/fishnet-on-edgegap/) should be updated to name port as "Game Port" instead of "UDP_PORT".
- Can be further rewritten to use the built-in `JSONUtility` instead of 3rd party `Leguar.TotalJSON`  dependency to parse the required fields.

